### PR TITLE
feat: Adds support for manual LLM-based validation when authoring assessment items

### DIFF
--- a/src/app/modules/authoring/assessment-items/assessment-items.component.html
+++ b/src/app/modules/authoring/assessment-items/assessment-items.component.html
@@ -1,7 +1,10 @@
 <div class="flex-col gap">
-    <small class="flex-row">
+    <small class="flex-row" style="align-items: center;">
+        <button mat-icon-button (click)="copyPrompt()" matTooltip="Kopiraj prompt za AI evaluaciju svih pitanja" color="primary">
+            <mat-icon>memory</mat-icon>
+        </button>
         <span style="flex-grow: 1;">
-            <b>Preporuke</b>: Sortiraj pitanja po težini; Izbegavaj reprodukciju činjenica i fokusiraj se na analizu primera; Definiši 1 hint za netrivijalna pitanja.
+            <b>Preporuke</b>: Sortiraj pitanja po težini; Izbegavaj reprodukciju činjenica i fokusiraj se na analizu primera; Definiši 1 hint za teža pitanja.
         </span>
         <span>
             <b>Broj pitanja</b>: {{ assessmentItems?.length }}

--- a/src/app/modules/authoring/assessment-items/assessment-items.component.html
+++ b/src/app/modules/authoring/assessment-items/assessment-items.component.html
@@ -16,6 +16,9 @@
                     <button mat-icon-button (click)="viewCommonWrongAnswers(item.id)" matTooltip="Najčešći pogrešni odgovori">
                         <mat-icon>bar_chart</mat-icon>
                     </button>
+                    <button mat-icon-button (click)="copyPrompt(item)" matTooltip="Kopiraj prompt za AI evaluaciju pitanja">
+                        <mat-icon>memory</mat-icon>
+                    </button>
                     <button mat-icon-button (click)="copyLink(item.id)" matTooltip="Kopiraj link do pitanja">
                         <mat-icon>link</mat-icon>
                     </button>
@@ -101,13 +104,13 @@
         </div>
         <div *ngIf="editMap[item.id]">
             <div *ngIf="item.$type === 'multiChoiceQuestion'">
-                <cc-mcq-form [item]="item" (saveChanges)="onCloseForm($event, item.id)"></cc-mcq-form>
+                <cc-mcq-form [item]="item" (saveChanges)="onCloseForm($event, item.id)" (requestPrompt)="copyPrompt($event)"></cc-mcq-form>
             </div>
             <div *ngIf="item.$type === 'multiResponseQuestion'">
-                <cc-mrq-form [item]="item" (saveChanges)="onCloseForm($event, item.id)"></cc-mrq-form>
+                <cc-mrq-form [item]="item" (saveChanges)="onCloseForm($event, item.id)" (requestPrompt)="copyPrompt($event)"></cc-mrq-form>
             </div>
             <div *ngIf="item.$type === 'shortAnswerQuestion'">
-                <cc-saq-form [item]="item" (saveChanges)="onCloseForm($event, item.id)"></cc-saq-form>
+                <cc-saq-form [item]="item" (saveChanges)="onCloseForm($event, item.id)" (requestPrompt)="copyPrompt($event)"></cc-saq-form>
             </div>
         </div>
     </mat-card>
@@ -125,13 +128,13 @@
             </button>
         </span>
         <div *ngIf="editMap[0]?.$type === 'multiChoiceQuestion'">
-            <cc-mcq-form [item]="editMap[0]" (saveChanges)="onCloseForm($event)"></cc-mcq-form>
+            <cc-mcq-form [item]="editMap[0]" (saveChanges)="onCloseForm($event)" (requestPrompt)="copyPrompt($event)"></cc-mcq-form>
         </div>
         <div *ngIf="editMap[0]?.$type === 'multiResponseQuestion'">
-            <cc-mrq-form [item]="editMap[0]" (saveChanges)="onCloseForm($event)"></cc-mrq-form>
+            <cc-mrq-form [item]="editMap[0]" (saveChanges)="onCloseForm($event)" (requestPrompt)="copyPrompt($event)"></cc-mrq-form>
         </div>
         <div *ngIf="editMap[0]?.$type === 'shortAnswerQuestion'">
-            <cc-saq-form [item]="editMap[0]" (saveChanges)="onCloseForm($event)"></cc-saq-form>
+            <cc-saq-form [item]="editMap[0]" (saveChanges)="onCloseForm($event)" (requestPrompt)="copyPrompt($event)"></cc-saq-form>
         </div>
     </mat-card>
 </div>

--- a/src/app/modules/authoring/assessment-items/assessment-items.component.ts
+++ b/src/app/modules/authoring/assessment-items/assessment-items.component.ts
@@ -150,13 +150,18 @@ export class AssessmentItemsComponent implements OnInit, CanComponentDeactivate 
     this.clipboard.copy(baseUrl + "?aiId=" + aiId);
   }
 
-  copyPrompt(ai: AssessmentItem) {
+  copyPrompt(ai?: AssessmentItem) {
     this.promptService.getAll('authoring').subscribe(prompts => {
       const assessmentPrompt = prompts.find(p => p.code === 'questions');
       if(!assessmentPrompt) return;
       
-      this.selectedAi = ai.id;
-      this.clipboard.copy(assessmentPrompt.content + prepareForPrompt(ai));
+      if(ai) {
+        this.selectedAi = ai.id;
+        this.clipboard.copy(assessmentPrompt.content + prepareForPrompt(ai));
+      } else {
+        const allQuestions = this.assessmentItems.map(a => prepareForPrompt(a)).join("\n");
+        this.clipboard.copy(`${assessmentPrompt.content}\n<questions>${allQuestions}</questions>`);
+      }
     });
   }
 }

--- a/src/app/modules/authoring/assessment-items/assessment-items.component.ts
+++ b/src/app/modules/authoring/assessment-items/assessment-items.component.ts
@@ -7,6 +7,8 @@ import { AssessmentItemsService } from './assessment-items.service';
 import { AssessmentItem } from './model/assessment-item.model';
 import { SubmissionStatisticsComponent } from '../../knowledge-analytics/submission-statistics/submission-statistics.component';
 import { CanComponentDeactivate } from 'src/app/infrastructure/confirm-leave.guard';
+import { AuthoringPromptsService } from '../authoring-prompts.service';
+import { prepareForPrompt } from './prompt.utility';
 
 @Component({
   selector: 'cc-assessment-items',
@@ -20,7 +22,7 @@ export class AssessmentItemsComponent implements OnInit, CanComponentDeactivate 
   clone: boolean = false;
   selectedAi: number;
 
-  constructor(private assessmentService: AssessmentItemsService,
+  constructor(private assessmentService: AssessmentItemsService, private promptService: AuthoringPromptsService,
     private route: ActivatedRoute, private dialog: MatDialog, private clipboard: Clipboard) { }
   
   canDeactivate(): boolean {
@@ -146,5 +148,15 @@ export class AssessmentItemsComponent implements OnInit, CanComponentDeactivate 
     this.selectedAi = aiId;
     const baseUrl = window.location.href.split('?')[0];
     this.clipboard.copy(baseUrl + "?aiId=" + aiId);
+  }
+
+  copyPrompt(ai: AssessmentItem) {
+    this.promptService.getAll('authoring').subscribe(prompts => {
+      const assessmentPrompt = prompts.find(p => p.code === 'questions');
+      if(!assessmentPrompt) return;
+      
+      this.selectedAi = ai.id;
+      this.clipboard.copy(assessmentPrompt.content + prepareForPrompt(ai));
+    });
   }
 }

--- a/src/app/modules/authoring/assessment-items/mcq-form/mcq-form.component.html
+++ b/src/app/modules/authoring/assessment-items/mcq-form/mcq-form.component.html
@@ -1,7 +1,11 @@
 <div class="flex-row theme-highlight-primary" style="height: 48px; align-items: center;">
-    <small class="flex-row" style="flex-grow: 1; align-items: center; padding-left: 10px;">
+    <small class="flex-row" style="align-items: center; padding-left: 10px;">
         <b>Tip:</b>&nbsp;Pitanje sa višestrukim izborom i jednim odgovorom
     </small>
+    <button mat-icon-button (click)="copyPrompt()" matTooltip="Kopiraj prompt za AI evaluaciju pitanja">
+        <mat-icon>memory</mat-icon>
+    </button>
+    <span style="flex-grow: 1"></span>
     <span class="flex-row gap">
         <button mat-mini-fab color="primary" [disabled]="form.invalid || workingItem.text==''" (click)="save()">
           <mat-icon>check</mat-icon>

--- a/src/app/modules/authoring/assessment-items/mcq-form/mcq-form.component.ts
+++ b/src/app/modules/authoring/assessment-items/mcq-form/mcq-form.component.ts
@@ -11,6 +11,7 @@ export class McqFormComponent implements OnInit {
   @Input() item: MultipleChoiceQuestion;
   workingItem: MultipleChoiceQuestion;
   @Output() saveChanges = new EventEmitter<MultipleChoiceQuestion>();
+  @Output() requestPrompt = new EventEmitter<MultipleChoiceQuestion>();
 
   form: FormGroup
 
@@ -70,12 +71,21 @@ export class McqFormComponent implements OnInit {
   }
 
   save(): void {
+    this.getFormData();
+    this.saveChanges.emit(this.workingItem);
+  }
+
+  private getFormData() {
     this.workingItem.correctAnswer = this.form.value['correctAnswer'];
     this.workingItem.feedback = this.form.value['feedback'];
     this.workingItem.possibleAnswers = this.form.value['options'].map((o: any) => o['text']);
     this.workingItem.possibleAnswers.unshift(this.form.value['correctAnswer']);
     this.workingItem.hints = this.form.value['hints'].map((o: any) => o['text']);
-    this.saveChanges.emit(this.workingItem);
+  }
+
+  copyPrompt() {
+    this.getFormData();
+    this.requestPrompt.emit(this.workingItem);
   }
 
   cancel(): void {

--- a/src/app/modules/authoring/assessment-items/mrq-form/mrq-form.component.html
+++ b/src/app/modules/authoring/assessment-items/mrq-form/mrq-form.component.html
@@ -1,7 +1,11 @@
 <div class="flex-row theme-highlight-primary" style="height: 48px; align-items: center;">
-    <small class="flex-row" style="flex-grow: 1; align-items: center; padding-left: 10px;">
+    <small class="flex-row" style="align-items: center; padding-left: 10px;">
         <b>Tip:</b>&nbsp;Pitanje sa višestrukim izborom i više odgovara
     </small>
+    <button mat-icon-button (click)="copyPrompt()" matTooltip="Kopiraj prompt za AI evaluaciju pitanja">
+        <mat-icon>memory</mat-icon>
+    </button>
+    <span style="flex-grow: 1"></span>
     <span class="flex-row gap">
         <button mat-mini-fab color="primary" [disabled]="form.invalid || workingItem.text=='' || options.length == 0" (click)="save()">
           <mat-icon>check</mat-icon>

--- a/src/app/modules/authoring/assessment-items/mrq-form/mrq-form.component.ts
+++ b/src/app/modules/authoring/assessment-items/mrq-form/mrq-form.component.ts
@@ -11,6 +11,7 @@ export class MrqFormComponent implements OnInit {
   @Input() item: MultipleReponseQuestion;
   workingItem: MultipleReponseQuestion;
   @Output() saveChanges = new EventEmitter<MultipleReponseQuestion>();
+  @Output() requestPrompt = new EventEmitter<MultipleReponseQuestion>();
 
   form: FormGroup
 
@@ -69,9 +70,18 @@ export class MrqFormComponent implements OnInit {
   }
 
   save(): void {
+    this.getFormData();
+    this.saveChanges.emit(this.workingItem);
+  }
+
+  private getFormData() {
     this.workingItem.items = this.form.value['options'];
     this.workingItem.hints = this.form.value['hints'].map((o: any) => o['text']);
-    this.saveChanges.emit(this.workingItem);
+  }
+
+  copyPrompt() {
+    this.getFormData();
+    this.requestPrompt.emit(this.workingItem);
   }
 
   cancel(): void {

--- a/src/app/modules/authoring/assessment-items/prompt.utility.ts
+++ b/src/app/modules/authoring/assessment-items/prompt.utility.ts
@@ -1,0 +1,69 @@
+import { AssessmentItem } from './model/assessment-item.model';
+import { MultipleChoiceQuestion } from './model/mcq.model';
+import { MultipleReponseQuestion } from './model/mrq.model';
+import { ShortAnswerQuestion } from './model/saq.model';
+
+export function prepareForPrompt(ai: AssessmentItem): string {
+  switch(ai.$type) {
+    case 'multiChoiceQuestion': return prepareMcq(ai as MultipleChoiceQuestion);
+    case 'multiResponseQuestion': return prepareMrq(ai as MultipleReponseQuestion);
+    case 'shortAnswerQuestion': return prepareSaq(ai as ShortAnswerQuestion);
+  }
+  return "";
+}
+
+function prepareMcq(ai: MultipleChoiceQuestion): string {
+  return `
+<question>
+  <text>
+    ${ai.text}
+  </text>
+  <correctOption>${ai.correctAnswer}</correctOption>
+  <distractors>
+  ${ai.possibleAnswers
+    .filter(a => a !== ai.correctAnswer)
+    .map((a) => `<distractor>${a}</distractor>`)
+    .join('\n')}
+  </distractors>
+  <feedback>${ai.feedback}</feedback>
+</question>
+`;
+}
+
+function prepareMrq(ai: MultipleReponseQuestion): string {
+  return `
+<question>
+  <text>
+    ${ai.text}
+  </text>
+  <options>
+    ${ai.items.map((o) => `
+    <option>
+      <text>${o.text}</text>
+      <is-correct>${o.isCorrect}</is-correct>
+      <feedback>${o.feedback}</feedback>
+    </option>`
+      ).join('\n')}
+  </options>
+</question>
+`;
+}
+
+function prepareSaq(ai: ShortAnswerQuestion): string {
+  return `
+<question>
+  <text>
+    ${ai.text}
+  </text>
+  <answer>
+    ${ai.acceptableAnswers
+      .map((ans) => `
+    <text>${ans}</text>`)
+      .join('\n')}
+  </answer>
+  <feedback>
+    ${ai.feedback}
+  </feedback>
+</question>
+`;
+}

--- a/src/app/modules/authoring/assessment-items/saq-form/saq-form.component.html
+++ b/src/app/modules/authoring/assessment-items/saq-form/saq-form.component.html
@@ -1,7 +1,11 @@
 <div class="flex-row theme-highlight-primary" style="height: 48px; align-items: center;">
-    <small class="flex-row" style="flex-grow: 1; align-items: center; padding-left: 10px;">
+    <small class="flex-row" style="align-items: center; padding-left: 10px;">
         <b>Tip:</b>&nbsp;Otvoreno pitanje sa kratkim odgovorom
     </small>
+    <button mat-icon-button (click)="copyPrompt()" matTooltip="Kopiraj prompt za AI evaluaciju pitanja">
+        <mat-icon>memory</mat-icon>
+    </button>
+    <span style="flex-grow: 1"></span>
     <span class="flex-row gap">
         <button mat-mini-fab color="primary" [disabled]="form.invalid || workingItem.text=='' || options.length == 0" (click)="save()">
           <mat-icon>check</mat-icon>

--- a/src/app/modules/authoring/assessment-items/saq-form/saq-form.component.ts
+++ b/src/app/modules/authoring/assessment-items/saq-form/saq-form.component.ts
@@ -11,6 +11,7 @@ export class SaqFormComponent implements OnInit {
   @Input() item: ShortAnswerQuestion;
   workingItem: ShortAnswerQuestion;
   @Output() saveChanges = new EventEmitter<ShortAnswerQuestion>();
+  @Output() requestPrompt = new EventEmitter<ShortAnswerQuestion>();
 
   form: FormGroup
 
@@ -69,11 +70,20 @@ export class SaqFormComponent implements OnInit {
   }
 
   save(): void {
+    this.getFormData();
+    this.saveChanges.emit(this.workingItem);
+  }
+
+  private getFormData() {
     this.workingItem.feedback = this.form.value['feedback'];
     this.workingItem.tolerance = this.form.value['tolerance'];
     this.workingItem.acceptableAnswers = this.form.value['options'].map((o: any) => o['text']);
     this.workingItem.hints = this.form.value['hints'].map((o: any) => o['text']);
-    this.saveChanges.emit(this.workingItem);
+  }
+
+  copyPrompt() {
+    this.getFormData();
+    this.requestPrompt.emit(this.workingItem);
   }
 
   cancel(): void {

--- a/src/app/modules/authoring/authoring-prompts.service.ts
+++ b/src/app/modules/authoring/authoring-prompts.service.ts
@@ -1,0 +1,27 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable, of, tap } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class AuthoringPromptsService {
+  private promptCache: Map<string, SystemPrompt[]> = new Map();
+  
+  constructor(private http: HttpClient) { }
+
+  getAll(category: string): Observable<SystemPrompt[]> {
+    if (this.promptCache.has(category)) {
+      return of(this.promptCache.get(category)!);
+    }
+  
+    return this.http.get<SystemPrompt[]>(`${environment.apiHost}authoring/prompts`).pipe(
+      tap(prompts => this.promptCache.set(category, prompts))
+    );
+  }
+}
+
+export interface SystemPrompt {
+  category: string;
+  code: string;
+  content: string;
+}


### PR DESCRIPTION
### Change Goal
- Support instructors in reducing errors when authoring assessment items.

### UI Changes
- Adds 2 buttons on the assessment item authoring page:
   - The blue button creates a prompt with all questions
   - The black button creates a prompt for the chosen question
![image](https://github.com/user-attachments/assets/830aa95a-550b-402b-8501-2b424de3aad2)

